### PR TITLE
Add 2 new types of evaluation

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ const END_TAG = '>'
 const EMBEDDED_TEMPLATE = '%'
 const ESCAPE = '-'
 const INTERPOLATE = '='
+const SLURP = '_'
+const COMMENT = '#'
 
 module.exports = function lexer (input) {
   const tokens = []
@@ -36,6 +38,12 @@ module.exports = function lexer (input) {
         advance()
       } else if (current(INTERPOLATE)) {
         type = 'interpolate'
+        advance()
+      } else if (current(COMMENT)) {
+        type = 'comment'
+        advance()
+      } else if (current(SLURP)) {
+        type = 'slurp'
         advance()
       } else {
         type = 'evaluate'

--- a/test.js
+++ b/test.js
@@ -37,6 +37,14 @@ assert.deepEqual(lexer('<%= bar %>'), [
   { type: 'interpolate', value: 'bar' }
 ])
 
+assert.deepEqual(lexer('<%_ bar %>'), [
+  { type: 'slurp', value: 'bar' }
+])
+
+assert.deepEqual(lexer('<%# bar %>'), [
+  { type: 'comment', value: 'bar' }
+])
+
 assert.deepEqual(lexer('<%=bar%>'), [
   { type: 'interpolate', value: 'bar' }
 ])


### PR DESCRIPTION
Based on the http://ejs.co Tags section, added other tags that seemd important as a token.
`<%%` as been ignored as its role is to escape the ejs interpretation.